### PR TITLE
fix: use golang:15 for tests and build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ workspace:
 
 steps:
 - name: test
-  image: golang:latest
+  image: golang:1.15
   environment:
   commands:
     - GO111MODULE=on go test -v ./...
@@ -17,7 +17,7 @@ steps:
       - pull_request
 
 - name: build
-  image: golang:latest
+  image: golang:1.15
   commands:
     - make build
   when:


### PR DESCRIPTION
The `make build` command fails since golang:1.16 with the following error:

```
❯ docker run --rm -it -v $(pwd):/drone/src golang:1.16
root@2c04899d824f:/go# cd /drone/src/
root@2c04899d824f:/drone/src# make build
. ./scripts/shared_env && ./scripts/build_binary.sh ./bin/local  e795928
+++ dirname ./scripts/build_binary.sh
++ cd ./scripts/..
++ pwd
+ ROOT=/drone/src
+ cd /drone/src
+ mkdir -p ./bin/local
+ cd /drone/src
+ package_root=github.com/davidbyttow/drone-ecr-registry-plugin
+ version_ldflags=
+ [[ -n e795928 ]]
+ version_ldflags='-X github.com/davidbyttow/drone-ecr-registry-plugin/version.Version=e795928'
+ [[ -n '' ]]
+ GOOS=
+ GOARCH=
+ CGO_ENABLED=0
+ go build -installsuffix cgo -a -ldflags '-s -X github.com/davidbyttow/drone-ecr-registry-plugin/version.Version=e795928' -o ./bin/local/drone-ecr-registry-plugin ./cmd
go: downloading github.com/sirupsen/logrus v1.2.0
go: downloading github.com/drone/drone-go v0.8.5-0.20181126001606-1b7bf6421356
go: downloading github.com/kelseyhightower/envconfig v1.3.0
go: downloading github.com/awslabs/amazon-ecr-credential-helper v0.2.0
go: downloading github.com/pkg/errors v0.8.0
go: downloading github.com/99designs/httpsignatures-go v0.0.0-20170731043157-88528bf4ca7e
go: downloading golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85
go: downloading github.com/mitchellh/go-homedir v1.0.0
go: downloading golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b
/go/pkg/mod/github.com/awslabs/amazon-ecr-credential-helper@v0.2.0/ecr-login/api/client.go:25:2: missing go.sum entry for module providing package github.com/aws/aws-sdk-go/aws (imported by github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api); to add:
	go get github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api@v0.2.0
/go/pkg/mod/github.com/awslabs/amazon-ecr-credential-helper@v0.2.0/ecr-login/cache/build.go:22:2: missing go.sum entry for module providing package github.com/aws/aws-sdk-go/aws/credentials (imported by github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cache); to add:
	go get github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cache@v0.2.0
/go/pkg/mod/github.com/awslabs/amazon-ecr-credential-helper@v0.2.0/ecr-login/api/factory.go:18:2: missing go.sum entry for module providing package github.com/aws/aws-sdk-go/aws/endpoints (imported by github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api); to add:
	go get github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api@v0.2.0
/go/pkg/mod/github.com/awslabs/amazon-ecr-credential-helper@v0.2.0/ecr-login/api/factory.go:19:2: missing go.sum entry for module providing package github.com/aws/aws-sdk-go/aws/request (imported by github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api); to add:
	go get github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api@v0.2.0
/go/pkg/mod/github.com/awslabs/amazon-ecr-credential-helper@v0.2.0/ecr-login/api/factory.go:20:2: missing go.sum entry for module providing package github.com/aws/aws-sdk-go/aws/session (imported by github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api); to add:
	go get github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api@v0.2.0
/go/pkg/mod/github.com/awslabs/amazon-ecr-credential-helper@v0.2.0/ecr-login/api/client.go:26:2: missing go.sum entry for module providing package github.com/aws/aws-sdk-go/service/ecr (imported by github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api); to add:
	go get github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api@v0.2.0
/go/pkg/mod/github.com/awslabs/amazon-ecr-credential-helper@v0.2.0/ecr-login/api/client.go:27:2: missing go.sum entry for module providing package github.com/aws/aws-sdk-go/service/ecr/ecriface (imported by github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api); to add:
	go get github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api@v0.2.0
make: *** [Makefile:16: bin/local/docker-ecr-registry-plugin] Error 1
```